### PR TITLE
Avoid MSVC warning in tests

### DIFF
--- a/test/test.hpp
+++ b/test/test.hpp
@@ -118,7 +118,7 @@ namespace any_tests // test utilities
 
     inline void check_non_null(const void * ptr, const std::string & description)
     {
-        check(ptr, "expected non-null pointer: " + description);
+        check(ptr != 0, "expected non-null pointer: " + description);
     }
 }
 


### PR DESCRIPTION
Visual C++ emits the following warning on implicit conversions from pointers to bool:
"warning C4800: 'const void *': forcing value to bool 'true' or 'false' (performance warning)"
Fixed by explicitly comparing the pointer to 0.
